### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities
 
+## [2.0.0] - 2020.11.10
+
+### Changed
+
+- Changed `dispatch`, `dispatchTo` and `dispatchToFallback` methods to no longer include named routes as a parameter.
+They can now accept an array of user-defined parameters instead. 
+
 ## [1.1.2] - 2020.11.06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -785,9 +785,11 @@ Returns URL of a named route.
 
 Dispatches the incoming HTTP request by searching for a matching redirect, route, automapped location, or fallback.
 
+Destination-specific parameters will overwrite global parameters of the same key.
+
 **Parameters:**
 
-- `$include_named_routes = true` (bool): Include array of named routes as a parameter to the destination?
+- `$params = []` (array): Global parameters to pass to all destinations 
 
 **Returns:**
 
@@ -837,7 +839,6 @@ Destinations can be a callable function, a named route, a file, or a `$class->me
 
 - `$destination` (mixed)
 - `$params = []` (array): Parameters to pass to the destination
-- `$include_named_routes = true` (bool): Include array of named routes as a parameter to the destination?
 
 **Returns:**
 
@@ -865,9 +866,11 @@ try {
 
 Dispatches to fallback for current request method, or throws exception.
 
+Fallback-specific parameters defined using the `addFallback` method will overwrite these parameters of the same key.
+
 **Parameters:**
 
-- `$include_named_routes = true` (bool): Include array of named routes as a parameter to the destination?
+- `$params = []` (array): Parameters to pass to the destination
 
 **Returns:**
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "ext-ctype": "*",
     "bayfrontmedia/php-array-helpers": "^1.0.1",
     "bayfrontmedia/php-http-request": "^2.0.0",
-    "bayfrontmedia/php-http-response": "^1.0.0",
+    "bayfrontmedia/php-http-response": "^1.1.0",
     "bayfrontmedia/php-string-helpers": "^1.0.0"
   },
   "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0bc338b0c8cda8e5a474bac3f732a020",
+    "content-hash": "d4bd2bb76a6a82f799545b2db9565650",
     "packages": [
         {
             "name": "bayfrontmedia/php-array-helpers",


### PR DESCRIPTION
### Changed

- Changed `dispatch`, `dispatchTo` and `dispatchToFallback` methods to no longer include named routes as a parameter.
They can now accept an array of user-defined parameters instead. 